### PR TITLE
Custom compass names

### DIFF
--- a/data/mojotitles/advancement/used_compass_on_lodestone.json
+++ b/data/mojotitles/advancement/used_compass_on_lodestone.json
@@ -1,0 +1,33 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:item_used_on_block",
+      "conditions": {
+        "location": [
+          {
+            "condition": "minecraft:all_of",
+            "terms": [
+              {
+                "condition": "minecraft:match_tool",
+                "predicate": {
+                  "items": "minecraft:compass"
+                }
+              },
+              {
+                "condition": "minecraft:location_check",
+                "predicate": {
+                  "block": {
+                    "blocks": "minecraft:lodestone"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "mojotitles:compass_naming/used_on_lodestone"
+  }
+}

--- a/data/mojotitles/function/banner_placement/found_attached_block.mcfunction
+++ b/data/mojotitles/function/banner_placement/found_attached_block.mcfunction
@@ -1,4 +1,19 @@
+execute align xyz run summon minecraft:marker ~ ~ ~ {Tags:["mojotitles.attached_block"]}
+
+execute store result entity @s data.mojotitles.attached_block.x int 1 \
+    run data get entity @e[tag=mojotitles.attached_block,limit=1] Pos[0]
+
+execute store result entity @s data.mojotitles.attached_block.y int 1 \
+    run data get entity @e[tag=mojotitles.attached_block,limit=1] Pos[1]
+
+execute store result entity @s data.mojotitles.attached_block.z int 1 \
+    run data get entity @e[tag=mojotitles.attached_block,limit=1] Pos[2]
+
+kill @e[tag=mojotitles.attached_block]
+
 execute unless block ~ ~ ~ minecraft:lodestone run return fail
+
+data modify entity @s data.mojotitles.attached_block.type set value "minecraft:lodestone"
 
 data modify storage mojotitles:temp WIPBanner set value {"enabled": true}
 

--- a/data/mojotitles/function/compass_naming/inventory_loop.mcfunction
+++ b/data/mojotitles/function/compass_naming/inventory_loop.mcfunction
@@ -1,0 +1,10 @@
+execute unless data storage mojotitles:temp Inventory[0] run return fail
+
+data modify storage mojotitles:temp InventoryItem set from storage mojotitles:temp Inventory[0]
+data remove storage mojotitles:temp Inventory[0]
+
+$execute if data storage mojotitles:temp \
+    InventoryItem.components."minecraft:lodestone_tracker".target{pos: [I; $(x), $(y), $(z)]} \
+    run function mojotitles:compass_naming/name_compass with storage mojotitles:temp InventoryItem
+
+function mojotitles:compass_naming/inventory_loop with entity @s data.mojotitles.attached_block

--- a/data/mojotitles/function/compass_naming/lodestone_location.mcfunction
+++ b/data/mojotitles/function/compass_naming/lodestone_location.mcfunction
@@ -1,0 +1,3 @@
+data modify storage mojotitles:temp Inventory set from entity @a[tag=mojotitles.player_used_compass,limit=1] Inventory
+
+function mojotitles:compass_naming/inventory_loop with entity @s data.mojotitles.attached_block

--- a/data/mojotitles/function/compass_naming/name_compass.mcfunction
+++ b/data/mojotitles/function/compass_naming/name_compass.mcfunction
@@ -1,0 +1,6 @@
+$execute at @s run item modify entity @a[tag=mojotitles.player_used_compass,limit=1] \
+    container.$(Slot) mojotitles:set_compass_name
+
+$execute if data entity @s data.mojotitles.lore[0] \
+    at @s run item modify entity @a[tag=mojotitles.player_used_compass,limit=1] \
+        container.$(Slot) mojotitles:set_compass_lore

--- a/data/mojotitles/function/compass_naming/used_on_lodestone.mcfunction
+++ b/data/mojotitles/function/compass_naming/used_on_lodestone.mcfunction
@@ -1,0 +1,9 @@
+advancement revoke @s only mojotitles:used_compass_on_lodestone
+
+tag @s add mojotitles.player_used_compass
+
+execute as @e[tag=mojotitles.banner_marker,distance=..8] \
+    if data entity @s data.mojotitles.attached_block{type:"minecraft:lodestone"} \
+    run function mojotitles:compass_naming/lodestone_location
+
+tag @s remove mojotitles.player_used_compass

--- a/data/mojotitles/item_modifier/set_compass_lore.json
+++ b/data/mojotitles/item_modifier/set_compass_lore.json
@@ -1,0 +1,14 @@
+{
+  "function": "minecraft:set_lore",
+  "entity": "this",
+  "lore": [
+    {
+      "nbt": "data.mojotitles.lore[0]",
+      "entity": "@s",
+      "source": "entity",
+      "type": "nbt"
+    }
+  ],
+  "mode": "replace_all",
+  "conditions": []
+}

--- a/data/mojotitles/item_modifier/set_compass_name.json
+++ b/data/mojotitles/item_modifier/set_compass_name.json
@@ -1,0 +1,21 @@
+[
+  {
+    "function": "minecraft:set_name",
+    "entity": "this",
+    "name": {
+      "nbt": "CustomName",
+      "block": "~ ~ ~",
+      "source": "block",
+      "type": "nbt",
+      "interpret": true
+    },
+    "conditions": []
+  },
+  {
+    "function": "minecraft:set_lore",
+    "entity": "this",
+    "lore": [],
+    "mode": "replace_all",
+    "conditions": []
+  }
+]


### PR DESCRIPTION
If a compass is used on a lodestone with an attached enchanted banner, set the compass's name and lore to match the banner