### PR TITLE
Configurable title targets

### DIFF
--- a/data/mojotitles/function/player_detector/detected_player.mcfunction
+++ b/data/mojotitles/function/player_detector/detected_player.mcfunction
@@ -1,3 +1,3 @@
-tag @s add mojotitles.player_detector.detected
+tag @s add mojotitles.triggering_player
 function mojotitles:title/show
-tag @s remove mojotitles.player_detector.detected
+tag @s remove mojotitles.triggering_player

--- a/data/mojotitles/function/players/players_within_range.mcfunction
+++ b/data/mojotitles/function/players/players_within_range.mcfunction
@@ -1,0 +1,2 @@
+$execute at @e[type=minecraft:marker,tag=mojotitles.active_marker] \
+    run tag @a[distance=..$(distance)] add mojotitles.players.sees_title

--- a/data/mojotitles/function/players/tag_loop.mcfunction
+++ b/data/mojotitles/function/players/tag_loop.mcfunction
@@ -4,6 +4,12 @@ data modify storage mojotitles:temp Player set from storage mojotitles:temp Play
 data remove storage mojotitles:temp Players[0]
 
 execute if data storage mojotitles:temp Player{type:"mojotitles:triggering_player"} \
-    run tag @a[tag=mojotitles.player_detector.detected] add mojotitles.players.sees_title
+    run tag @a[tag=mojotitles.triggering_player] add mojotitles.players.sees_title
+
+execute if data storage mojotitles:temp Player{type:"mojotitles:all_players"} \
+    run tag @a add mojotitles.players.sees_title
+
+execute if data storage mojotitles:temp Player{type:"mojotitles:players_within_range"} \
+    run function mojotitles:players/players_within_range with storage mojotitles:temp Player
 
 function mojotitles:players/tag_loop

--- a/data/mojotitles/function/ui/action.mcfunction
+++ b/data/mojotitles/function/ui/action.mcfunction
@@ -1,0 +1,16 @@
+execute if score @s mojotitles.ui.action matches 1 \
+    run function mojotitles:ui/cancel
+
+execute if score @s mojotitles.ui.action matches 2 \
+    run function mojotitles:ui/main/show_dialog
+
+execute if score @s mojotitles.ui.action matches 101 \
+    run function mojotitles:ui/player_detection_distance/show_dialog
+
+execute if score @s mojotitles.ui.action matches 102 \
+    run function mojotitles:ui/players/rotate_value
+
+execute if score @s mojotitles.ui.action matches 103 \
+    run function mojotitles:ui/player_announcement_distance/show_dialog
+
+scoreboard players reset @s mojotitles.ui.action

--- a/data/mojotitles/function/ui/cancel.mcfunction
+++ b/data/mojotitles/function/ui/cancel.mcfunction
@@ -1,3 +1,2 @@
 function mojotitles:ui/clear_interaction_target
-
-scoreboard players reset @a mojotitles.ui.cancel
+dialog clear @s

--- a/data/mojotitles/function/ui/interact.mcfunction
+++ b/data/mojotitles/function/ui/interact.mcfunction
@@ -1,3 +1,3 @@
 advancement revoke @s only mojotitles:interacted_with_proclamation_banner
 
-function mojotitles:ui/main
+function mojotitles:ui/main/show_dialog

--- a/data/mojotitles/function/ui/load.mcfunction
+++ b/data/mojotitles/function/ui/load.mcfunction
@@ -1,5 +1,11 @@
+scoreboard objectives add mojotitles.ui.action trigger
+scoreboard players reset @a mojotitles.ui.action
+
 scoreboard objectives add mojotitles.ui.cancel trigger
 scoreboard players reset @a mojotitles.ui.cancel
 
 scoreboard objectives add mojotitles.ui.player_detection_distance trigger
 scoreboard players reset @a mojotitles.ui.player_detection_distance
+
+scoreboard objectives add mojotitles.ui.player_announcement_distance trigger
+scoreboard players reset @a mojotitles.ui.player_announcement_distance

--- a/data/mojotitles/function/ui/main/components/player_announcement_range.mcfunction
+++ b/data/mojotitles/function/ui/main/components/player_announcement_range.mcfunction
@@ -1,0 +1,26 @@
+data modify storage mojotitles:temp WIPDialogAction set value {\
+    label: [\
+      "Player announcement range: ",\
+      {\
+        text: "",\
+        color: "yellow"\
+      }\
+    ],\
+    width: 200,\
+    tooltip: "Click to edit",\
+    action: {\
+        type: "run_command",\
+        command: "trigger mojotitles.ui.action set 103"\
+    }\
+}
+
+data modify storage mojotitles:temp stringify.input \
+  set from storage mojotitles:temp current_marker_data.players[0].distance
+
+function mojotitles:utils/stringify with storage mojotitles:temp stringify
+
+data modify storage mojotitles:temp WIPDialogAction.label[1].text \
+  set from storage mojotitles:temp stringified
+
+data modify storage mojotitles:dialog dialog.actions \
+  append from storage mojotitles:temp WIPDialogAction

--- a/data/mojotitles/function/ui/main/components/player_detection_range.mcfunction
+++ b/data/mojotitles/function/ui/main/components/player_detection_range.mcfunction
@@ -1,0 +1,26 @@
+data modify storage mojotitles:temp WIPDialogAction set value {\
+    label: [\
+      "Player detection range: ",\
+      {\
+        text: "",\
+        color: "yellow"\
+      }\
+    ],\
+    width: 200,\
+    tooltip: "Click to edit",\
+    action: {\
+        type: "run_command",\
+        command: "trigger mojotitles.ui.action set 101"\
+    }\
+}
+
+data modify storage mojotitles:temp stringify.input \
+  set from storage mojotitles:temp current_marker_data.triggers[0].distance
+
+function mojotitles:utils/stringify with storage mojotitles:temp stringify
+
+data modify storage mojotitles:temp WIPDialogAction.label[1].text \
+  set from storage mojotitles:temp stringified
+
+data modify storage mojotitles:dialog dialog.actions \
+  append from storage mojotitles:temp WIPDialogAction

--- a/data/mojotitles/function/ui/main/components/triggering_player.mcfunction
+++ b/data/mojotitles/function/ui/main/components/triggering_player.mcfunction
@@ -1,0 +1,27 @@
+data modify storage mojotitles:temp WIPDialogAction set value {\
+    label: [\
+      "Show title to: ",\
+      {\
+        text: "",\
+        color: "yellow"\
+      }\
+    ],\
+    width: 200,\
+    tooltip: "Click to edit",\
+    action: {\
+        type: "run_command",\
+        command: "trigger mojotitles.ui.action set 102"\
+    }\
+}
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:triggering_player"}] \
+  run data modify storage mojotitles:temp WIPDialogAction.label[1].text set value "triggering player only"
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:all_players"}] \
+  run data modify storage mojotitles:temp WIPDialogAction.label[1].text set value "all players"
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:players_within_range"}] \
+  run data modify storage mojotitles:temp WIPDialogAction.label[1].text set value "players within range"
+
+data modify storage mojotitles:dialog dialog.actions \
+  append from storage mojotitles:temp WIPDialogAction

--- a/data/mojotitles/function/ui/main/show_dialog.mcfunction
+++ b/data/mojotitles/function/ui/main/show_dialog.mcfunction
@@ -1,0 +1,32 @@
+function mojotitles:ui/get_marker_data
+
+data modify storage mojotitles:temp foo set value "bar"
+
+data modify storage mojotitles:dialog dialog set value {\
+    type: "minecraft:multi_action",\
+    title: "Proclamations",\
+    body: {\
+        type: "minecraft:plain_message",\
+        contents: "Currently configured banner options:"\
+    },\
+    columns: 1,\
+    pause: false,\
+    after_action: "none",\
+    exit_action: {\
+        label: "Done",\
+        action: {\
+          type: "run_command",\
+          command: "trigger mojotitles.ui.action set 1"\
+        }\
+    },\
+    actions: []\
+}
+
+function mojotitles:ui/main/components/player_detection_range
+
+function mojotitles:ui/main/components/triggering_player
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:players_within_range"}] \
+    run function mojotitles:ui/main/components/player_announcement_range
+
+function mojotitles:ui/show_dialog with storage mojotitles:dialog

--- a/data/mojotitles/function/ui/player_announcement_distance/set_value.mcfunction
+++ b/data/mojotitles/function/ui/player_announcement_distance/set_value.mcfunction
@@ -6,11 +6,11 @@ execute \
     if function mojotitles:ui/check_target \
     on passengers \
     as @s[type=minecraft:marker,tag=mojotitles.banner] \
-    store result entity @s data.mojotitles.triggers[0].distance int 1 \
-    run scoreboard players get @a[tag=mojotitles.player_checking_target,limit=1] mojotitles.ui.player_detection_distance
+    store result entity @s data.mojotitles.players[0].distance int 1 \
+    run scoreboard players get @a[tag=mojotitles.player_checking_target,limit=1] mojotitles.ui.player_announcement_distance
 
 tag @s remove mojotitles.player_checking_target
 
-scoreboard players reset @a mojotitles.ui.player_detection_distance
+scoreboard players reset @a mojotitles.ui.player_announcement_distance
 
-function mojotitles:ui/clear_interaction_target
+function mojotitles:ui/main/show_dialog

--- a/data/mojotitles/function/ui/player_announcement_distance/show_dialog.mcfunction
+++ b/data/mojotitles/function/ui/player_announcement_distance/show_dialog.mcfunction
@@ -1,0 +1,41 @@
+function mojotitles:ui/get_marker_data
+
+data modify storage mojotitles:dialog dialog set value {\
+  type: "minecraft:confirmation",\
+  title: "Banner Settings",\
+  pause: 0,\
+  after_action: "none",\
+  body: {\
+    type: "minecraft:plain_message",\
+    contents: "Announce title to players in this range"\
+  },\
+  inputs: [\
+    {\
+      type: "minecraft:number_range",\
+      label: "Announcement range (blocks)",\
+      key: "announcement_distance",\
+      start: 0,\
+      end: 256,\
+      step: 1\
+    }\
+  ],\
+  yes: {\
+    action: {\
+      type: "minecraft:dynamic/run_command",\
+      template: "trigger mojotitles.ui.player_announcement_distance set $(announcement_distance)"\
+    },\
+    label: "Confirm"\
+  },\
+  no: {\
+    action: {\
+      type: "run_command",\
+      command: "trigger mojotitles.ui.action set 2"\
+    },\
+    label: "Cancel"\
+  }\
+}
+
+data modify storage mojotitles:dialog dialog.inputs[0].initial \
+    set from storage mojotitles:temp current_marker_data.players[0].distance
+
+function mojotitles:ui/show_dialog with storage mojotitles:dialog

--- a/data/mojotitles/function/ui/player_detection_distance/set_value.mcfunction
+++ b/data/mojotitles/function/ui/player_detection_distance/set_value.mcfunction
@@ -1,0 +1,16 @@
+tag @s add mojotitles.player_checking_target
+
+execute \
+    at @s \
+    as @e[type=minecraft:interaction,tag=mojotitles.banner,distance=..10] \
+    if function mojotitles:ui/check_target \
+    on passengers \
+    as @s[type=minecraft:marker,tag=mojotitles.banner] \
+    store result entity @s data.mojotitles.triggers[0].distance int 1 \
+    run scoreboard players get @a[tag=mojotitles.player_checking_target,limit=1] mojotitles.ui.player_detection_distance
+
+tag @s remove mojotitles.player_checking_target
+
+scoreboard players reset @a mojotitles.ui.player_detection_distance
+
+function mojotitles:ui/main/show_dialog

--- a/data/mojotitles/function/ui/player_detection_distance/show_dialog.mcfunction
+++ b/data/mojotitles/function/ui/player_detection_distance/show_dialog.mcfunction
@@ -4,7 +4,7 @@ data modify storage mojotitles:dialog dialog set value {\
   type: "minecraft:confirmation",\
   title: "Banner Settings",\
   pause: 0,\
-  after_action: "close",\
+  after_action: "none",\
   body: {\
     type: "minecraft:plain_message",\
     contents: "Detect players within this distance"\
@@ -29,7 +29,7 @@ data modify storage mojotitles:dialog dialog set value {\
   no: {\
     action: {\
       type: "run_command",\
-      command: "trigger mojotitles.ui.cancel"\
+      command: "trigger mojotitles.ui.action set 2"\
     },\
     label: "Cancel"\
   }\

--- a/data/mojotitles/function/ui/players/rotate_value.mcfunction
+++ b/data/mojotitles/function/ui/players/rotate_value.mcfunction
@@ -1,0 +1,31 @@
+function mojotitles:ui/get_marker_data
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:triggering_player"}] \
+  run data modify storage mojotitles:temp TargetPlayerSpec set value {type: "mojotitles:all_players"}
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:all_players"}] \
+  run data modify storage mojotitles:temp TargetPlayerSpec set value {type: "mojotitles:players_within_range", distance: 64}
+
+execute if data storage mojotitles:temp current_marker_data.players[{type:"mojotitles:players_within_range"}] \
+  run data modify storage mojotitles:temp TargetPlayerSpec set value {type: "mojotitles:triggering_player"}
+
+data modify storage mojotitles:temp CurrentPlayerSpec \
+  set from storage mojotitles:temp current_marker_data.players[0]
+
+data remove storage mojotitles:temp CurrentPlayerSpec.type
+
+data modify storage mojotitles:temp TargetPlayerSpec merge from storage mojotitles:temp CurrentPlayerSpec
+
+tag @s add mojotitles.player_checking_target
+
+execute \
+    at @s \
+    as @e[type=minecraft:interaction,tag=mojotitles.banner,distance=..10] \
+    if function mojotitles:ui/check_target \
+    on passengers \
+    as @s[type=minecraft:marker,tag=mojotitles.banner] \
+    run data modify entity @s data.mojotitles.players[0] set from storage mojotitles:temp TargetPlayerSpec
+
+tag @s remove mojotitles.player_checking_target
+
+function mojotitles:ui/main/show_dialog

--- a/data/mojotitles/function/ui/tick.mcfunction
+++ b/data/mojotitles/function/ui/tick.mcfunction
@@ -1,7 +1,15 @@
+scoreboard players enable @a mojotitles.ui.action
+execute as @a if score @s mojotitles.ui.action matches 1.. \
+    run function mojotitles:ui/action
+    
 scoreboard players enable @a mojotitles.ui.cancel
 execute as @a if score @s mojotitles.ui.cancel matches 1.. \
     run function mojotitles:ui/cancel
 
 scoreboard players enable @a mojotitles.ui.player_detection_distance
 execute as @a if score @s mojotitles.ui.player_detection_distance matches 1.. \
-    run function mojotitles:ui/set_player_detection_distance
+    run function mojotitles:ui/player_detection_distance/set_value
+
+scoreboard players enable @a mojotitles.ui.player_announcement_distance
+execute as @a if score @s mojotitles.ui.player_announcement_distance matches 1.. \
+    run function mojotitles:ui/player_announcement_distance/set_value

--- a/data/mojotitles/function/utils/stringify.mcfunction
+++ b/data/mojotitles/function/utils/stringify.mcfunction
@@ -1,0 +1,1 @@
+$data modify storage mojotitles:temp stringified set value "$(input)"


### PR DESCRIPTION
Add dialog option to configure which players are shown the title: the triggering player, players within a block range of the banner, or all players