### PR TITLE
Display named items as sprites

### DIFF
--- a/data/proclamations/dialog/help/inventory_detectors.json
+++ b/data/proclamations/dialog/help/inventory_detectors.json
@@ -93,6 +93,49 @@
     {
       "type": "minecraft:plain_message",
       "contents": {
+        "text": "Sprites / Item Textures",
+        "color": "dark_aqua"
+      },
+      "width": 256
+    },
+    {
+      "type": "minecraft:plain_message",
+      "contents": "You can rename any of the following items in an anvil with the name of a sprite or item texture - e.g. 'item/emerald' or 'yourresourcepack:item/yourtexture' - to display that texture as part of the message.",
+      "width": 256
+    },
+    {
+      "type": "minecraft:item",
+      "item": {
+        "id": "minecraft:painting"
+      },
+      "description": {
+        "contents": "Painting: displayed as a title",
+        "width": 256
+      }
+    },
+    {
+      "type": "minecraft:item",
+      "item": {
+        "id": "minecraft:item_frame"
+      },
+      "description": {
+        "contents": "Item frame: displayed as a subtitle",
+        "width": 256
+      }
+    },
+    {
+      "type": "minecraft:item",
+      "item": {
+        "id": "minecraft:glow_item_frame"
+      },
+      "description": {
+        "contents": "Glow item frame: displayed in the action bar",
+        "width": 256
+      }
+    },
+    {
+      "type": "minecraft:plain_message",
+      "contents": {
         "text": "Player Targets",
         "color": "dark_aqua"
       },
@@ -120,7 +163,7 @@
         }
       },
       "description": {
-        "contents": "A player is considered to be \"detected\" if a player head matching their profile is found in the shulker box.",
+        "contents": "A player is considered to be \"detected\" if a player head matching their profile is found in the shulker box. Optionally, in the configuration menu you can choose to display player head textures in the title, subtitle or action bar.",
         "width": 256
       }
     }

--- a/data/proclamations/function/marker/inventory_detector/add_custom_name.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/add_custom_name.mcfunction
@@ -1,4 +1,13 @@
-data modify storage proclamations:temp NewTextComponent set value {"text": ""}
+data modify storage proclamations:temp NewTextComponent set value {}
+
+execute if function proclamations:marker/inventory_detector/is_painting \
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_title
+
+execute if function proclamations:marker/inventory_detector/is_item_frame \
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_subtitle
+
+execute if function proclamations:marker/inventory_detector/is_glow_item_frame \
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_actionbar
 
 # try: assume component is compound NBT text component, merge all keys
 execute store result score #success_count proclamations.temp \
@@ -12,24 +21,16 @@ execute if score #success_count proclamations.temp matches 0 \
 
 # If item is wool, use it as a title component, with its color as the default color
 execute if function proclamations:marker/inventory_detector/is_wool \
-    run return \
-    run data modify storage proclamations:temp ContainerTitleTextComponents \
-        append from storage proclamations:temp NewTextComponent
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_title
 
 # If item is carpet, use it as a subtitle component, with its color as the default color
 execute if function proclamations:marker/inventory_detector/is_carpet \
-    run return \
-    run data modify storage proclamations:temp ContainerSubtitleTextComponents \
-        append from storage proclamations:temp NewTextComponent
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_subtitle
 
 # If item is banner, use it as an actionbar component, with its color as the default color
 execute if function proclamations:marker/inventory_detector/is_banner \
-    run return \
-    run data modify storage proclamations:temp ContainerActionbarTextComponents \
-        append from storage proclamations:temp NewTextComponent
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_actionbar
 
-# Otherwise, use the item as a title component
-data modify storage proclamations:temp ContainerTitleTextComponents \
-    append from storage proclamations:temp NewTextComponent
+function proclamations:marker/inventory_detector/add_text_component_to_title
 
 data remove storage proclamations:temp NewTextComponent

--- a/data/proclamations/function/marker/inventory_detector/add_text_component_to_actionbar.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/add_text_component_to_actionbar.mcfunction
@@ -1,0 +1,5 @@
+execute if data storage proclamations:temp ContainerActionbarTextComponents[0] \
+    run data modify storage proclamations:temp ContainerActionbarTextComponents append value {"text": " "}
+
+data modify storage proclamations:temp ContainerActionbarTextComponents \
+    append from storage proclamations:temp NewTextComponent

--- a/data/proclamations/function/marker/inventory_detector/add_text_component_to_subtitle.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/add_text_component_to_subtitle.mcfunction
@@ -1,0 +1,5 @@
+execute if data storage proclamations:temp ContainerSubtitleTextComponents[0] \
+    run data modify storage proclamations:temp ContainerSubtitleTextComponents append value {"text": " "}
+
+data modify storage proclamations:temp ContainerSubtitleTextComponents \
+    append from storage proclamations:temp NewTextComponent

--- a/data/proclamations/function/marker/inventory_detector/add_text_component_to_title.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/add_text_component_to_title.mcfunction
@@ -1,0 +1,5 @@
+execute if data storage proclamations:temp ContainerTitleTextComponents[0] \
+    run data modify storage proclamations:temp ContainerTitleTextComponents append value {"text": " "}
+
+data modify storage proclamations:temp ContainerTitleTextComponents \
+    append from storage proclamations:temp NewTextComponent

--- a/data/proclamations/function/marker/inventory_detector/is_glow_item_frame.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/is_glow_item_frame.mcfunction
@@ -1,0 +1,6 @@
+execute unless data storage proclamations:temp Item.item{id: "minecraft:glow_item_frame"} run return fail
+
+data modify storage proclamations:temp NewTextComponent set value {color: "white"}
+
+return run data modify storage proclamations:temp NewTextComponent.sprite \
+    set from storage proclamations:temp Item.item.components."minecraft:custom_name"

--- a/data/proclamations/function/marker/inventory_detector/is_item_frame.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/is_item_frame.mcfunction
@@ -1,0 +1,6 @@
+execute unless data storage proclamations:temp Item.item{id: "minecraft:item_frame"} run return fail
+
+data modify storage proclamations:temp NewTextComponent set value {color: "white"}
+
+return run data modify storage proclamations:temp NewTextComponent.sprite \
+    set from storage proclamations:temp Item.item.components."minecraft:custom_name"

--- a/data/proclamations/function/marker/inventory_detector/is_painting.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/is_painting.mcfunction
@@ -1,0 +1,6 @@
+execute unless data storage proclamations:temp Item.item{id: "minecraft:painting"} run return fail
+
+data modify storage proclamations:temp NewTextComponent set value {color: "white"}
+
+return run data modify storage proclamations:temp NewTextComponent.sprite \
+    set from storage proclamations:temp Item.item.components."minecraft:custom_name"

--- a/data/proclamations/function/marker/inventory_detector/tag_player_head_owner.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/tag_player_head_owner.mcfunction
@@ -1,30 +1,17 @@
 $tag $(name) add proclamations.triggering_player
 
-data modify storage proclamations:temp NewTextComponent set value []
+data modify storage proclamations:temp NewTextComponent set value {"color": "white"}
 
-execute if data storage proclamations:temp ContainerTitleTextComponents[0] \
-    run data modify storage proclamations:temp NewTextComponent \
-        append value {"text": " "}
-
-data modify storage proclamations:temp NewTextComponent append value {"color": "white"}
-
-data modify storage proclamations:temp NewTextComponent[-1].player \
+data modify storage proclamations:temp NewTextComponent.player \
     set from storage proclamations:temp Item.item.components."minecraft:profile"
 
-execute if data storage proclamations:temp DetectedInventoryContents[0] \
-    run data modify storage proclamations:temp NewTextComponent \
-        append value {"text": " "}
-
 execute if data entity @s data.proclamations.triggers[{display_player_heads:"in_title"}] \
-  run data modify storage proclamations:temp ContainerTitleTextComponents \
-    append from storage proclamations:temp NewTextComponent
+  run return run function proclamations:marker/inventory_detector/add_text_component_to_title
 
 execute if data entity @s data.proclamations.triggers[{display_player_heads:"in_subtitle"}] \
-  run data modify storage proclamations:temp ContainerSubtitleTextComponents \
-    append from storage proclamations:temp NewTextComponent
+  run return run function proclamations:marker/inventory_detector/add_text_component_to_subtitle
   
 execute if data entity @s data.proclamations.triggers[{display_player_heads:"in_actionbar"}] \
-  run data modify storage proclamations:temp ContainerActionbarTextComponents \
-    append from storage proclamations:temp NewTextComponent
+  run return run function proclamations:marker/inventory_detector/add_text_component_to_actionbar
 
 data remove storage proclamations:temp NewTextComponent


### PR DESCRIPTION
If paintings, item frames or glow item frames are renamed, interpret their names as sprites

Closes #27 