### PR TITLE
Inventory detectors: detect single player heads

### DIFF
--- a/data/proclamations/function/marker/inventory_detector/add_count.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/add_count.mcfunction
@@ -10,24 +10,16 @@ data modify storage proclamations:temp NewTextComponent.text \
 
 # If item is wool, use it as a title component, with its color as the default color
 execute if function proclamations:marker/inventory_detector/is_wool \
-    run return \
-    run data modify storage proclamations:temp ContainerTitleTextComponents \
-        append from storage proclamations:temp NewTextComponent
-        
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_title
+
 # If item is carpet, use it as a subtitle component, with its color as the default color
 execute if function proclamations:marker/inventory_detector/is_carpet \
-    run return \
-    run data modify storage proclamations:temp ContainerSubtitleTextComponents \
-        append from storage proclamations:temp NewTextComponent
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_subtitle
 
 # If item is banner, use it as an actionbar component, with its color as the default color
 execute if function proclamations:marker/inventory_detector/is_banner \
-    run return \
-    run data modify storage proclamations:temp ContainerActionbarTextComponents \
-        append from storage proclamations:temp NewTextComponent
+    run return run function proclamations:marker/inventory_detector/add_text_component_to_actionbar
 
-# Otherwise, use the item as a title component
-data modify storage proclamations:temp ContainerTitleTextComponents \
-    append from storage proclamations:temp NewTextComponent
+function proclamations:marker/inventory_detector/add_text_component_to_title
 
 data remove storage proclamations:temp NewTextComponent

--- a/data/proclamations/function/marker/inventory_detector/clear_text_components.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/clear_text_components.mcfunction
@@ -1,0 +1,3 @@
+data modify storage proclamations:temp ContainerTitleTextComponents set value []
+data modify storage proclamations:temp ContainerSubtitleTextComponents set value []
+data modify storage proclamations:temp ContainerActionbarTextComponents set value []

--- a/data/proclamations/function/marker/inventory_detector/detected_player_head.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/detected_player_head.mcfunction
@@ -1,0 +1,25 @@
+data modify storage proclamations:temp DetectedInventoryContents set value [{}]
+
+data modify storage proclamations:temp DetectedInventoryContents[0].item set from entity @s \
+     data.proclamations.container_inventory[{id:"minecraft:player_head"}]
+
+function proclamations:marker/inventory_detector/clear_text_components
+
+function proclamations:marker/inventory_detector/loop_container_contents
+
+data modify storage proclamations:temp TextComponent set from entity @s data.proclamations.title_text_components[0]
+execute if data storage proclamations:temp ContainerTitleTextComponents[0] \
+    run data modify storage proclamations:temp ContainerTitleTextComponents append value {text: " "}
+execute at @s run function proclamations:text_components/render_component/banner_name
+data modify storage proclamations:temp ContainerTitleTextComponents append from storage proclamations:temp RenderedTextComponent
+
+data modify storage proclamations:temp TextComponent set from entity @s data.proclamations.subtitle_text_components[0]
+execute if data storage proclamations:temp ContainerSubitleTextComponents[0] \
+    run data modify storage proclamations:temp ContainerSubtitleTextComponents append value {text: " "}
+execute at @s run function proclamations:text_components/render_component/banner_lore
+execute unless data storage proclamations:temp RenderedTextComponent{text: ""} \
+    run data modify storage proclamations:temp ContainerSubtitleTextComponents append from storage proclamations:temp RenderedTextComponent
+
+function proclamations:title/show
+
+tag @a[tag=proclamations.triggering_player] remove proclamations.triggering_player

--- a/data/proclamations/function/marker/inventory_detector/detected_shulker.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/detected_shulker.mcfunction
@@ -1,0 +1,10 @@
+data modify storage proclamations:temp DetectedInventoryContents set from entity @s \
+     data.proclamations.container_inventory[{components:{"minecraft:container":[{}]}}].components."minecraft:container"
+
+function proclamations:marker/inventory_detector/clear_text_components
+
+function proclamations:marker/inventory_detector/loop_container_contents
+
+function proclamations:title/show
+
+tag @a[tag=proclamations.triggering_player] remove proclamations.triggering_player

--- a/data/proclamations/function/marker/inventory_detector/tick.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/tick.mcfunction
@@ -4,17 +4,8 @@ $execute store success score #title_text_changed proclamations.temp \
 
 execute if score #title_text_changed proclamations.temp matches 0 run return fail
 
-execute unless data entity @s data.proclamations.container_inventory[{components:{"minecraft:container":[{}]}}] run return fail
+execute if data entity @s data.proclamations.container_inventory[{components:{"minecraft:container":[{}]}}] \
+    run return run function proclamations:marker/inventory_detector/detected_shulker
 
-data modify storage proclamations:temp DetectedInventoryContents set from entity @s \
-     data.proclamations.container_inventory[{components:{"minecraft:container":[{}]}}].components."minecraft:container"
-
-data modify storage proclamations:temp ContainerTitleTextComponents set value []
-data modify storage proclamations:temp ContainerSubtitleTextComponents set value []
-data modify storage proclamations:temp ContainerActionbarTextComponents set value []
-
-function proclamations:marker/inventory_detector/loop_container_contents
-
-function proclamations:title/show
-
-tag @a[tag=proclamations.triggering_player] remove proclamations.triggering_player
+execute if data entity @s data.proclamations.container_inventory[{id:"minecraft:player_head"}] \
+    run return run function proclamations:marker/inventory_detector/detected_player_head


### PR DESCRIPTION
If a single player head is seen by an inventory detector, display that banner's custom name and lore to that player