### PR TITLE
Support up to pack format 94 (Minecraft 1.21.11)

### DIFF
--- a/data/proclamations/function/marker/inventory_detector/is_glow_item_frame.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/is_glow_item_frame.mcfunction
@@ -1,6 +1,6 @@
 execute unless data storage proclamations:temp Item.item{id: "minecraft:glow_item_frame"} run return fail
 
-data modify storage proclamations:temp NewTextComponent set value {color: "white"}
+function proclamations:marker/inventory_detector/new_sprite_text_component
 
 execute store result score #text_component_count proclamations.temp run data get storage proclamations:temp Item.item.count
 

--- a/data/proclamations/function/marker/inventory_detector/is_item_frame.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/is_item_frame.mcfunction
@@ -1,6 +1,6 @@
 execute unless data storage proclamations:temp Item.item{id: "minecraft:item_frame"} run return fail
 
-data modify storage proclamations:temp NewTextComponent set value {color: "white"}
+function proclamations:marker/inventory_detector/new_sprite_text_component
 
 execute store result score #text_component_count proclamations.temp run data get storage proclamations:temp Item.item.count
 

--- a/data/proclamations/function/marker/inventory_detector/is_painting.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/is_painting.mcfunction
@@ -1,6 +1,6 @@
 execute unless data storage proclamations:temp Item.item{id: "minecraft:painting"} run return fail
 
-data modify storage proclamations:temp NewTextComponent set value {color: "white"}
+function proclamations:marker/inventory_detector/new_sprite_text_component
 
 execute store result score #text_component_count proclamations.temp run data get storage proclamations:temp Item.item.count
 

--- a/data/proclamations/function/marker/inventory_detector/new_sprite_text_component.mcfunction
+++ b/data/proclamations/function/marker/inventory_detector/new_sprite_text_component.mcfunction
@@ -1,0 +1,1 @@
+data modify storage proclamations:temp NewTextComponent set value {color: "white", atlas: "minecraft:items"}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,20 +1,29 @@
 {
   "pack": {
     "description": "§6Proclamations§r by MojoBeast: Add in-game announcements (using the /title command) to your Survival Mode builds.",
-    "pack_format": 88,
+    "pack_format": 94,
     "min_format": 71,
-    "max_format": 88,
-    "supported_formats": { "min_inclusive": 71, "max_inclusive": 88 }
+    "max_format": 94,
+    "supported_formats": { "min_inclusive": 71, "max_inclusive": 94 }
   },
   "overlays": {
     "entries": [
       {
         "directory": "pre_1_21_9",
         "min_format": 71,
-        "max_format": 81,
+        "max_format": 84,
         "formats": {
           "min_inclusive": 71,
-          "max_inclusive": 81
+          "max_inclusive": 84
+        }
+      },
+      {
+        "directory": "pre_1_21_11",
+        "min_format": 85,
+        "max_format": 92,
+        "formats": {
+          "min_inclusive": 85,
+          "max_inclusive": 92
         }
       }
     ]

--- a/pre_1_21_11/data/proclamations/function/marker/inventory_detector/new_sprite_text_component.mcfunction
+++ b/pre_1_21_11/data/proclamations/function/marker/inventory_detector/new_sprite_text_component.mcfunction
@@ -1,0 +1,2 @@
+# item textures were in the "minecraft:blocks" atlas prior to 1.21.11
+data modify storage proclamations:temp NewTextComponent set value {color: "white", atlas: "minecraft:blocks"}


### PR DESCRIPTION
Support up to pack format 94 (Minecraft 1.21.11) by supporting split into separate blocks and items atlases